### PR TITLE
Made memos look nicer

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,14 @@ $(() => {
           box-shadow: none;
           border: 1px solid #ddd;
           background: #eee;
+          border-radius: 4px;
+          max-width: 888px;
+          text-align: left;
           margin: 25px auto;
+      }
+
+      body .post .btn-leave {
+          float: right;
       }
 
       body #profile-list .btn {

--- a/index.js
+++ b/index.js
@@ -337,6 +337,14 @@ body .post {
     padding: 0;
 }
 
+body .post .actions {
+    margin: 10px;
+}
+
+body .post .likes {
+    margin: 10px;
+}
+
 body .post .name {
     background: #fff;
     border-radius: 5px 5px 0 0;


### PR DESCRIPTION
Centering text in memos makes everything look a bit dumb, so aligned text left, made the max-width 888px, and lowered the border-radius to 4 to not look so cartooney.
Also floated "view on blockchain" button right to separate less used "information features" from user actions.

![chrome_2018-04-20_16-01-27](https://user-images.githubusercontent.com/7502322/39055533-c75e4214-44b4-11e8-8c23-5a3816b26806.png)
